### PR TITLE
prevent a crash from machines that open multiple guis like SE cannons

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+    - prevent a crash from machines that open multiple guis like SE cannons
+
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.2
 Date: 14. 03. 2024

--- a/control.lua
+++ b/control.lua
@@ -94,6 +94,7 @@ function create_assembler_rate_gui(player, entity)
     -- we're going to need these, make them if they don't exist
     create_global_tables()
     -- the base frame, that everything goes into
+    if global.gui_data_by_player[player.index] then return end
     local gui_frame = player.gui.relative.add{type="frame", caption="Products", name="assembler-craft-rates-gui"}
 
     -- attach the new GUI to the correct machine type


### PR DESCRIPTION
Space Exploration Delivery Cannons have a primary gui, but also a targeting gui. In their particular case there simply isn't a need to open a different calculation windows. Also in general trying to create the gui if it already exists will always lead to a crash.

```
The mod Assembler Production Rates (0.1.2) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event assembler-craft-rates::on_gui_opened (ID 88)
Gui element with name assembler-craft-rates-gui already present in the parent element.
stack traceback:
	[C]: in function 'add'
	__assembler-craft-rates__/control.lua:97: in function 'create_assembler_rate_gui'
	__assembler-craft-rates__/control.lua:20: in function <__assembler-craft-rates__/control.lua:16>
stack traceback:
	[C]: in function '__newindex'
	__space-exploration__/scripts/remote-view.lua:694: in function 'start'
	__space-exploration__/scripts/delivery-cannon-gui.lua:338: in function 'callback'
	__space-exploration__/scripts/event.lua:20: in function <__space-exploration__/scripts/event.lua:18>
```